### PR TITLE
feat : Redirect URL Domian으로 수정

### DIFF
--- a/api/src/main/resources/prod/application-api.yaml
+++ b/api/src/main/resources/prod/application-api.yaml
@@ -9,4 +9,4 @@ spring:
 kakao:
   authorize-url: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={0}&redirect_uri={1}
   app-key: ENC(la2O8hAJw/5PQXn8KxMXPDaAdnyXKBCGLZeI1uRkka+m2hbbtz+FmdQg3RE/B/aE)
-  redirect-url: https://localhost:5173/kakao-login
+  redirect-url: https://mbtips.kr/kakao-login


### PR DESCRIPTION
## 기능 설명
카카오 로그인 Redirect URL 변경

## 작업 상세 내용
- `GET /api/kakao/authorize-url` 반환값 변경